### PR TITLE
Fix for TextEditor fields of item sheets not saving

### DIFF
--- a/src/module/items/base-sheet.ts
+++ b/src/module/items/base-sheet.ts
@@ -34,24 +34,6 @@ export class BaseSheet extends ItemSheet<DocumentSheet.Options, BaseSheetData> {
     super._injectHTML(html);
   }
 
-  // (name:string, options = {}:TextEditor.Options, initialContent = ""
-  activateEditor(
-    name: string,
-    options = {} as TextEditor.Options,
-    initialContent = ""
-  ): void {
-    const editor = this.editors[name];
-    if (!editor) throw new Error(`${name} is not a registered editor name!`);
-    options = foundry.utils.mergeObject(editor.options, options);
-    options.height = Math.max(options.height, options.target.offsetHeight, 100);
-    TextEditor.create(options, initialContent || editor.initial).then((mce) => {
-      editor.mce = mce;
-      editor.changed = false;
-      editor.active = true;
-      mce.focus();
-      mce.on("change", () => (editor.changed = true));
-    });
-  }
   /**
    * @override
    */


### PR DESCRIPTION
The root cause of this bug seems to be this overwrite. The API function it's overwriting returns an editor context, while this does not. As the overwrite seems to be doing absolutely nothing more than what the API function already does, the most immediate solution seems to be to simply delete it altogether.

I have given this a very limited test run, it does seem to fix the issue with item sheets (at least weapons, but they all inherit from here after all) and it doesn't seem to break anything, but please test it further before merging.