### PR TITLE
update to system.json 'compatibility' key for V11

### DIFF
--- a/src/system.yml
+++ b/src/system.yml
@@ -212,15 +212,14 @@ packs:
     module: swnr
     name: one-roll-backing
     path: packs/one-roll-backing.db
-    system: swnr    
+    system: swnr
 languages:
   - lang: en
     name: English
     path: lang/en.json
 gridDistance: 2
 gridUnits: "m"
-minimumCoreVersion: 0.8.6
-compatibleCoreVersion: 10.291
+compatibility: { "minimum": "0.8.6", "verified": "10.291" }
 url: "https://github.com/wintersleepAI/foundry-swnr"
 manifest: >-
   https://github.com/wintersleepAI/foundry-swnr/releases/latest/download/system.json


### PR DESCRIPTION
with V11 i got an error:
`The system "swnr" is using the old flat core compatibility fields which are deprecated in favor of the new "compatibility" object`

i believe this will fix it.